### PR TITLE
Fix samba option typo

### DIFF
--- a/machines/hoard/configuration.nix
+++ b/machines/hoard/configuration.nix
@@ -257,7 +257,7 @@ in
         "time-machine" = {
           "vfs objects" = "catia fruit streams_xattr";
           "fruit:time machine" = "yes";
-          "fruit: time machine max size" = "2T";
+          "fruit:time machine max size" = "2T";
           "fruit:metadata" = "stream";
           "fruit:wipe_intentionally_left_blank_rfork" = "yes";
           "fruit:delete_empty_adfiles" = "yes";


### PR DESCRIPTION
## Summary
- fix a typo in Samba `fruit:time machine max size` option

## Testing
- `nix` command not found, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_683f45ccbb3483278656f165a7a32603