### PR TITLE
Fix comment typo in sabnzbd module

### DIFF
--- a/modules/sabnzbd.nix
+++ b/modules/sabnzbd.nix
@@ -83,7 +83,7 @@ in
     };
 
     networking.firewall = mkIf cfg.openFirewall {
-      # TODO: decleratively configurable port
+      # TODO: declaratively configurable port
       allowedTCPPorts = [ 8085 ];
     };
   };


### PR DESCRIPTION
## Summary
- fix misspelling in sabnzbd firewall comment

## Testing
- `nix flake check --no-build --impure` *(fails: `bash: nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68440a41659c8327af95e1db4071b352