### PR TITLE
Fix qbittorrent firewall option reference

### DIFF
--- a/modules/qbittorrent.nix
+++ b/modules/qbittorrent.nix
@@ -51,7 +51,7 @@ in
       type = types.bool;
       default = false;
       description = lib.mdDoc ''
-        Open services.qBittorrent.port to the outside network.
+        Open services.qbittorrent.port to the outside network.
       '';
     };
 


### PR DESCRIPTION
## Summary
- fix firewall port reference in `modules/qbittorrent.nix`

## Testing
- `grep -n "Open services.qbittorrent" -n modules/qbittorrent.nix`


------
https://chatgpt.com/codex/tasks/task_e_68440a40c3548327b2b92da0b8af85ff