### PR TITLE
Add self-hosted ntfy on buoy and wire Gatus alerts to it

### DIFF
--- a/infra/buoy/dns.tf
+++ b/infra/buoy/dns.tf
@@ -27,3 +27,16 @@ import {
   to = cloudflare_dns_record.status
   id = "${var.cloudflare_zone_id}/${var.status_dns_record_id}"
 }
+
+# ntfy (machines/buoy/ntfy.nix) is served through the same tunnel. This is a new
+# record (no import), so `tf apply` creates it - replacing the manual
+# `cloudflared tunnel route dns buoy-tunnel ntfy.<domain>` step.
+resource "cloudflare_dns_record" "ntfy" {
+  zone_id = var.cloudflare_zone_id
+  name    = "ntfy.${var.domain_name}"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.buoy.id}.cfargotunnel.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "ntfy via buoy-tunnel"
+}

--- a/machines/buoy/cloudflare-tunnel.nix
+++ b/machines/buoy/cloudflare-tunnel.nix
@@ -16,7 +16,6 @@
         # CNAMEs to <tunnel-id>.cfargotunnel.com), not `cloudflared tunnel route dns`.
         "status.${config.my.domain}" =
           "http://localhost:${toString config.services.gatus.settings.web.port}";
-        # cloudflared tunnel route dns buoy-tunnel ntfy.<domain>
         # Target the exact loopback address ntfy binds (see ntfy.nix), so the
         # port is defined once. WebSocket subscriptions tunnel fine over this.
         "ntfy.${config.my.domain}" = "http://${config.services.ntfy-sh.settings.listen-http}";

--- a/machines/buoy/cloudflare-tunnel.nix
+++ b/machines/buoy/cloudflare-tunnel.nix
@@ -16,6 +16,10 @@
         # CNAMEs to <tunnel-id>.cfargotunnel.com), not `cloudflared tunnel route dns`.
         "status.${config.my.domain}" =
           "http://localhost:${toString config.services.gatus.settings.web.port}";
+        # cloudflared tunnel route dns buoy-tunnel ntfy.<domain>
+        # Target the exact loopback address ntfy binds (see ntfy.nix), so the
+        # port is defined once. WebSocket subscriptions tunnel fine over this.
+        "ntfy.${config.my.domain}" = "http://${config.services.ntfy-sh.settings.listen-http}";
       };
     };
   };

--- a/machines/buoy/default.nix
+++ b/machines/buoy/default.nix
@@ -21,6 +21,7 @@
     "${modulesPath}/virtualisation/google-compute-image.nix"
     ./filesystems.nix
     ./gatus.nix
+    ./ntfy.nix
     ./cloudflare-tunnel.nix
   ];
 

--- a/machines/buoy/gatus.nix
+++ b/machines/buoy/gatus.nix
@@ -22,6 +22,16 @@ let
         RESOLVED = builtins.toJSON resolved;
       };
     };
+
+  # ntfy runs alongside Telegram (see the alerting.ntfy provider below). Unlike
+  # the custom Telegram provider, the native ntfy provider builds the message
+  # itself and appends TRIGGERED/RESOLVED, so each alert only supplies a short
+  # description for context.
+  mkNtfyAlert = description: {
+    type = "ntfy";
+    inherit description;
+    send-on-resolved = true;
+  };
 in
 {
   services.gatus = {
@@ -33,6 +43,16 @@ in
       storage = {
         type = "sqlite";
         path = "/var/lib/gatus/data.db";
+      };
+      # Self-hosted ntfy on this same host (see ntfy.nix). The server is
+      # deny-all, so Gatus publishes with a write-only token. Gatus runs
+      # os.ExpandEnv over the whole config, so ${NTFY_TOKEN} (from the sops
+      # gatus.env) is substituted at load time, matching the Telegram token.
+      alerting.ntfy = {
+        url = "https://ntfy.${config.my.domain}";
+        topic = "buoy-status";
+        token = "\${NTFY_TOKEN}";
+        priority = 4;
       };
       alerting.custom = {
         url = "https://api.telegram.org/bot\${TELEGRAM_BOT_TOKEN}/sendMessage";
@@ -59,6 +79,7 @@ in
               triggered = "🔴 Інтернет зник.";
               resolved = "🟢 Інтернет знову є.";
             })
+            (mkNtfyAlert "Інтернет")
           ];
         }
         {
@@ -74,6 +95,7 @@ in
               triggered = "🔴 Overseerr недоступний.";
               resolved = "🟢 Overseerr знову доступний.";
             })
+            (mkNtfyAlert "Overseerr")
           ];
         }
         {
@@ -93,6 +115,7 @@ in
               triggered = "🔴 Plex недоступний.";
               resolved = "🟢 Plex знову доступний.";
             })
+            (mkNtfyAlert "Plex")
           ];
         }
       ];

--- a/machines/buoy/gatus.nix
+++ b/machines/buoy/gatus.nix
@@ -1,5 +1,6 @@
 {
   config,
+  lib,
   ...
 }:
 let
@@ -36,7 +37,6 @@ in
 {
   services.gatus = {
     enable = true;
-    environmentFile = config.sops.secrets.gatus-env.path;
     settings = {
       ui.custom-css = builtins.readFile ./gatus-gruvbox.css;
       web.address = "127.0.0.1";
@@ -45,9 +45,10 @@ in
         path = "/var/lib/gatus/data.db";
       };
       # Self-hosted ntfy on this same host (see ntfy.nix). The server is
-      # deny-all, so Gatus publishes with a write-only token. Gatus runs
-      # os.ExpandEnv over the whole config, so ${NTFY_TOKEN} (from the sops
-      # gatus.env) is substituted at load time, matching the Telegram token.
+      # deny-all, so Gatus publishes with the gatus write-only token. Gatus
+      # runs os.ExpandEnv over the whole config, so ${NTFY_TOKEN} (rendered
+      # into gatus-ntfy.env below from the same secret ntfy.nix provisions) is
+      # substituted at load time, matching the Telegram token.
       alerting.ntfy = {
         url = "https://ntfy.${config.my.domain}";
         topic = "buoy-status";
@@ -122,8 +123,20 @@ in
     };
   };
 
+  # Telegram credentials (existing) stay in gatus.env; the ntfy publish token is
+  # the same secret ntfy.nix provisions, rendered into its own file so it has a
+  # single source of truth. gatus's module takes one environmentFile, so load
+  # both via systemd instead (mkForce replaces the module's single-file list).
   sops.secrets.gatus-env = {
     sopsFile = ../../secrets/buoy/gatus.env;
     format = "dotenv";
   };
+  sops.templates."gatus-ntfy.env" = {
+    content = "NTFY_TOKEN=${config.sops.placeholder.ntfy-gatus-token}";
+    restartUnits = [ "gatus.service" ];
+  };
+  systemd.services.gatus.serviceConfig.EnvironmentFile = lib.mkForce [
+    config.sops.secrets.gatus-env.path
+    config.sops.templates."gatus-ntfy.env".path
+  ];
 }

--- a/machines/buoy/ntfy.nix
+++ b/machines/buoy/ntfy.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  ...
+}:
+{
+  # Self-hosted push notifications, exposed at ntfy.<domain> through the
+  # Cloudflare tunnel (see cloudflare-tunnel.nix). Subscribe from the ntfy
+  # mobile app or a browser; any service on the fleet can publish over HTTP
+  # with a token. First consumer wired up is Gatus (see gatus.nix).
+  services.ntfy-sh = {
+    enable = true;
+    settings = {
+      base-url = "https://ntfy.${config.my.domain}";
+      # Loopback only: the Cloudflare tunnel is the sole ingress. Set
+      # explicitly (matches the module default) so cloudflare-tunnel.nix can
+      # reference this exact address rather than duplicate the port.
+      listen-http = "127.0.0.1:2586";
+      # Trust X-Forwarded-For from cloudflared for rate limiting / real IPs.
+      behind-proxy = true;
+      # Private instance: nothing is readable or publishable without an
+      # account. Accounts and per-topic access are provisioned via the ntfy
+      # CLI (one-time step below).
+      auth-default-access = "deny-all";
+      # Instant iOS/Android delivery for a self-hosted server: ntfy forwards a
+      # content-free poll request to ntfy.sh, whose Firebase/APNs wakes the
+      # app, which then fetches the real message back from buoy. Only a topic
+      # hash derived from base-url leaves the box; message bodies stay local.
+      upstream-base-url = "https://ntfy.sh";
+    };
+  };
+
+  # One-time auth setup, run on buoy. State lives in the auth-file at
+  # /var/lib/ntfy-sh/user.db and survives reboots and redeploys; it is lost
+  # only if the VM is re-created (same durability as Gatus's data.db). The
+  # service creates the DB on first start, so run these afterwards. Run as the
+  # ntfy-sh service user so the SQLite file keeps the right ownership; the CLI
+  # reads the generated config at /etc/ntfy/server.yml automatically.
+  #
+  #   sudo -u ntfy-sh ntfy user add --role=admin <me>       # app / browser login
+  #   sudo -u ntfy-sh ntfy user add gatus                   # status-page publisher
+  #   sudo -u ntfy-sh ntfy access gatus buoy-status write-only
+  #   sudo -u ntfy-sh ntfy token add --label gatus gatus    # prints tk_...
+  #
+  # Put the tk_... token in secrets/buoy/gatus.env as NTFY_TOKEN=<token> (sops),
+  # then redeploy so Gatus can publish to the buoy-status topic.
+}

--- a/machines/buoy/ntfy.nix
+++ b/machines/buoy/ntfy.nix
@@ -18,8 +18,7 @@
       # Trust X-Forwarded-For from cloudflared for rate limiting / real IPs.
       behind-proxy = true;
       # Private instance: nothing is readable or publishable without an
-      # account. Accounts and per-topic access are provisioned via the ntfy
-      # CLI (one-time step below).
+      # account (accounts are provisioned declaratively below).
       auth-default-access = "deny-all";
       # Instant iOS/Android delivery for a self-hosted server: ntfy forwards a
       # content-free poll request to ntfy.sh, whose Firebase/APNs wakes the
@@ -27,20 +26,43 @@
       # hash derived from base-url leaves the box; message bodies stay local.
       upstream-base-url = "https://ntfy.sh";
     };
+    # Declarative accounts/ACL/tokens via the env file rendered below. ntfy
+    # reconciles these against its auth DB on every start and deletes anything
+    # no longer listed, so accounts are managed like NixOS users
+    # (mutableUsers = false) - never via the `ntfy user` CLI on the box.
+    environmentFile = config.sops.templates."ntfy.env".path;
   };
 
-  # One-time auth setup, run on buoy. State lives in the auth-file at
-  # /var/lib/ntfy-sh/user.db and survives reboots and redeploys; it is lost
-  # only if the VM is re-created (same durability as Gatus's data.db). The
-  # service creates the DB on first start, so run these afterwards. Run as the
-  # ntfy-sh service user so the SQLite file keeps the right ownership; the CLI
-  # reads the generated config at /etc/ntfy/server.yml automatically.
+  # ntfy requires a bcrypt password per account even when auth is by token, so
+  # both accounts carry a throwaway hash and authenticate with an access token
+  # (the "key" analogue - like this box's own key-only login). Only the hashes
+  # and tokens are secret; the account/topic/role structure is declared in the
+  # template below, the ntfy equivalent of a declarative users.users.* with a
+  # hashedPasswordFile.
   #
-  #   sudo -u ntfy-sh ntfy user add --role=admin <me>       # app / browser login
-  #   sudo -u ntfy-sh ntfy user add gatus                   # status-page publisher
-  #   sudo -u ntfy-sh ntfy access gatus buoy-status write-only
-  #   sudo -u ntfy-sh ntfy token add --label gatus gatus    # prints tk_...
-  #
-  # Put the tk_... token in secrets/buoy/gatus.env as NTFY_TOKEN=<token> (sops),
-  # then redeploy so Gatus can publish to the buoy-status topic.
+  # secrets/buoy/ntfy.yaml was generated with a CSPRNG (bcrypt cost 10, 32-char
+  # tk_ tokens) and encrypted to the buoy and glib age keys. To read the admin
+  # token for the mobile app / browser, or to rotate any value:
+  #   sops secrets/buoy/ntfy.yaml
+  # It is not yet encrypted to the YubiKey; add it with the usual rekey step:
+  #   sops updatekeys secrets/buoy/ntfy.yaml
+  sops.secrets = {
+    ntfy-admin-password-hash.sopsFile = ../../secrets/buoy/ntfy.yaml;
+    ntfy-admin-token.sopsFile = ../../secrets/buoy/ntfy.yaml;
+    ntfy-gatus-password-hash.sopsFile = ../../secrets/buoy/ntfy.yaml;
+    ntfy-gatus-token.sopsFile = ../../secrets/buoy/ntfy.yaml;
+  };
+
+  # admin: role=admin -> read + publish every topic (no ACL entry needed), used
+  # from your phone/browser via its token. gatus: write-only to its own topic
+  # only. Lists are comma-separated and reconciled on every restart (entries
+  # removed here are deleted from the DB). The gatus topic must match gatus.nix.
+  sops.templates."ntfy.env" = {
+    content = ''
+      NTFY_AUTH_USERS=admin:${config.sops.placeholder.ntfy-admin-password-hash}:admin,gatus:${config.sops.placeholder.ntfy-gatus-password-hash}:user
+      NTFY_AUTH_ACCESS=gatus:buoy-status:write-only
+      NTFY_AUTH_TOKENS=admin:${config.sops.placeholder.ntfy-admin-token},gatus:${config.sops.placeholder.ntfy-gatus-token}
+    '';
+    restartUnits = [ "ntfy-sh.service" ];
+  };
 }

--- a/secrets/buoy/ntfy.yaml
+++ b/secrets/buoy/ntfy.yaml
@@ -1,0 +1,33 @@
+ntfy-admin-password-hash: ENC[AES256_GCM,data:Z07oD4locg706ZEm7B+S202MmWBx4jzGTt2WjJ4/MP1/AjVFQUmEavrVFVvNgG8fsNvgFmOrt0vdlEVq,iv:Y+Hm6s5RiHqPjZ8WWmLDxVGb3Tu6MDxbjRHCqDr91uE=,tag:gPjEdJzUEXctxkVwu5w41A==,type:str]
+ntfy-admin-token: ENC[AES256_GCM,data:3uX/baUFvP5fJRgOaYqS/JugLMh+WVOLfBKc+zNflN8=,iv:kIZPgcfV3bkkKAaYTuvdG8g+dGk5k4Y3P3T8X9M8BcM=,tag:hrn2WwDGKBjtTsVEhZ4dSg==,type:str]
+ntfy-gatus-password-hash: ENC[AES256_GCM,data:bHlZHtIgcUYUMpu8jHo4xGrgsGIRCl1dNMead1hZGTUKcOygmbTQaNe8TSE//iZnjRKqdvO65powunHs,iv:9aM//OkcpH9+WyIqnbM3XhBtMvNhq5cxKpF5aseLOHM=,tag:zMyDpCf9+E0/N0URfTqoCw==,type:str]
+ntfy-gatus-token: ENC[AES256_GCM,data:MPTy/aivTeUEoMpKHMVQDo9k0tIKMxs4vgioSiBk1h8=,iv:M1CmqJGTLWwMu0i/WlGlINgbTR43jNaF3U5L3POhUt0=,tag:YcN5KlesmdQW6W/uELZXAg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1n2s86y3uf6q7ss5mpktzj4utuyff4v7h0zh8ygk9q9v4p5qvxf0s30vtg0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnWjEwRnF1RjUrQXFLYWJI
+            S1pjdlFKUHNIVTYwb3pEamROMmpnRjlXc1RNClRlVTkvYzNnZE1UNDB3NGxhcVMv
+            WXo0UStwN0c5WndSeForRFdXbTdYZjAKLS0tIDVENW9yQWpQZVc4OVo1MGxKdjUv
+            Wlc5N0dKNXZuZFlyZ2E5azk3UkdQakUKQ14sGWkvpceDus4RpVqQXe0FHCf//MCm
+            fdgL83PMj6/nEr92Qm5Qi1WDObk0hEvEL8mGPAWBwxv6rJfBKEWupQ==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1y85cqvae5fkm03hk4py2uty60jdc7yf7gdu98nakmpp8l66cg4rs4fhgg6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhK1VBZzEwUGRPSk9pT1Qw
+            WW5hbmRVZVRTOVlNZGtHQzRJalE1U3NHSWxZCkdkSXBmNVVDbXkzK095L3orbDF5
+            OFRUUVRSeEdwbGNRTGplZUxwRVVGdUkKLS0tIDZ3UjdlZzJRMmtVWCt2dDEyR0Rn
+            dE9sUkE4QzJyZW5jZld6VTNrWU9UUUkKpYVcMEdsvp+CHJlLP5g/CsCfNly/Irnt
+            +UvSCaDXaDngpVMm+R4mfhObHDyHQJH1NCpeD5+QpP0cGGu/Yiae/w==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-15T16:33:02Z"
+    mac: ENC[AES256_GCM,data:Kn6rOeVZmUsXX3vGjf8FcukISuujAreuLeX+wVOawe89cNmCtyE9GVXgR4RF2lKkTMJIJSYLfs/VxFSxL9xYpS4CjL7rVt4E/w1+QscIm8rD3kOVrUZATRMrwpiiV472p9uaHpV1k0sXejV8fMDJZh/orryKhCocFzzxevbOHmM=,iv:BJCjnCr6+9fI0k4ft/+31GbBEcptc7UxcfglzeftBhw=,tag:FUTF4BlyoYrqrGZ6HtyLbw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.9.4


### PR DESCRIPTION
## What

Self-hosted [ntfy](https://ntfy.sh) on **buoy** at `ntfy.glib.sh`, with Gatus publishing to it alongside Telegram. Accounts are provisioned declaratively (no CLI on the box), and DNS is declarative too.

**Stacked PR:** this targets `claude/buoy-tunnel-terraform` (#9, which brings the tunnel + its DNS into Terraform). Once #9 merges to `main`, re-point this PR's base to `main`. The diff here is the ntfy-specific work on top of #9.

## Changes

- **`machines/buoy/ntfy.nix`** (new) — `services.ntfy-sh`: `deny-all`, loopback bind, `behind-proxy`, `upstream-base-url` for instant iOS/Android push. Accounts/ACL/tokens provisioned declaratively via `sops.templates` → `environmentFile`; ntfy reconciles them on restart (like `mutableUsers = false`). Structure in Nix, hashes/token from sops.
- **`secrets/buoy/ntfy.yaml`** (new) — CSPRNG-generated bcrypt hashes + `tk_` tokens, encrypted to the buoy + `glib_op` age keys.
- **`machines/buoy/gatus.nix`** — native `ntfy` alerting provider (topic `buoy-status`) + `mkNtfyAlert` on each endpoint; `NTFY_TOKEN` sourced from the same provisioned gatus token via a second `EnvironmentFile`. Telegram unchanged.
- **`machines/buoy/default.nix`** — import `ntfy.nix`.
- **`machines/buoy/cloudflare-tunnel.nix`** — `ntfy.<domain>` ingress → ntfy's loopback bind.
- **`infra/buoy/dns.tf`** — `ntfy.<domain>` proxied CNAME to the Terraform-managed tunnel (`cloudflare_zero_trust_tunnel_cloudflared.buoy.id`, from #9). No `cloudflared tunnel route dns` step.

## Your steps to activate (after #9 is applied)

1. `sops updatekeys secrets/buoy/ntfy.yaml` — add the YubiKey recipient (currently age-only; buoy can already decrypt).
2. `tf apply` (with #9's tunnel adopted) creates the `ntfy.glib.sh` CNAME.
3. Deploy buoy: `nixos-rebuild switch --flake .#buoy --target-host buoy --sudo`.
4. Phone: `sops -d secrets/buoy/ntfy.yaml` → copy `ntfy-admin-token`, add server `https://ntfy.glib.sh` in the ntfy app with that access token, subscribe to `buoy-status`.

Until deploy, Telegram keeps alerting and ntfy sends are simply rejected — no impact on the status page.

## Verification

`nix flake check` runs in CI (no Nix in the session). `treefmt` formats only `.nix/.lua/.sh/.toml/.py`, so the sops YAML is untouched. Terraform isn't validated locally — see #9 for the `tf plan` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)