### PR TITLE
Manage buoy Cloudflare tunnel and its DNS in Terraform

### DIFF
--- a/infra/buoy/dns.tf
+++ b/infra/buoy/dns.tf
@@ -7,3 +7,23 @@ resource "cloudflare_dns_record" "vm" {
   proxied = false
   comment = "GCP VM static IP for SSH access"
 }
+
+# The Gatus status page (machines/buoy/gatus.nix) is served through the
+# Cloudflare tunnel, so status.<domain> is a proxied CNAME to the tunnel. It
+# was previously created with `cloudflared tunnel route dns buoy-tunnel
+# status.<domain>`; the import block adopts that existing record unchanged.
+# Remove the import block after the first successful apply.
+resource "cloudflare_dns_record" "status" {
+  zone_id = var.cloudflare_zone_id
+  name    = "status.${var.domain_name}"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.buoy.id}.cfargotunnel.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+  comment = "Gatus status page via buoy-tunnel"
+}
+
+import {
+  to = cloudflare_dns_record.status
+  id = "${var.cloudflare_zone_id}/${var.status_dns_record_id}"
+}

--- a/infra/buoy/tunnel.tf
+++ b/infra/buoy/tunnel.tf
@@ -1,0 +1,25 @@
+# Manage the buoy-tunnel Cloudflare Tunnel declaratively (it was previously
+# created out of band with `cloudflared tunnel create buoy-tunnel`).
+# config_src = "local" keeps the ingress/routing config on the box, managed by
+# cloudflared via machines/buoy/cloudflare-tunnel.nix - Terraform owns only the
+# tunnel's existence and secret, not its routes.
+#
+# Adopting the already-running tunnel with no downtime:
+#   - The import block below takes the live tunnel into state by its id, so it
+#     is not recreated.
+#   - cloudflare_tunnel_secret must be the tunnel's EXISTING secret (the
+#     TunnelSecret in `sops -d secrets/buoy/cloudflare-tunnel.json`) so the
+#     apply does not rotate it - buoy's credentials file stays valid.
+# Verify `tf plan` shows no change that rotates tunnel_secret before applying.
+# The import block can be removed after the first successful apply.
+resource "cloudflare_zero_trust_tunnel_cloudflared" "buoy" {
+  account_id    = var.cloudflare_account_id
+  name          = "buoy-tunnel"
+  config_src    = "local"
+  tunnel_secret = var.cloudflare_tunnel_secret
+}
+
+import {
+  to = cloudflare_zero_trust_tunnel_cloudflared.buoy
+  id = "${var.cloudflare_account_id}/${var.cloudflare_tunnel_id}"
+}

--- a/infra/buoy/tunnel.tf
+++ b/infra/buoy/tunnel.tf
@@ -1,22 +1,19 @@
 # Manage the buoy-tunnel Cloudflare Tunnel declaratively (it was previously
 # created out of band with `cloudflared tunnel create buoy-tunnel`).
 # config_src = "local" keeps the ingress/routing config on the box, managed by
-# cloudflared via machines/buoy/cloudflare-tunnel.nix - Terraform owns only the
-# tunnel's existence and secret, not its routes.
+# cloudflared via machines/buoy/cloudflare-tunnel.nix.
 #
-# Adopting the already-running tunnel with no downtime:
-#   - The import block below takes the live tunnel into state by its id, so it
-#     is not recreated.
-#   - cloudflare_tunnel_secret must be the tunnel's EXISTING secret (the
-#     TunnelSecret in `sops -d secrets/buoy/cloudflare-tunnel.json`) so the
-#     apply does not rotate it - buoy's credentials file stays valid.
-# Verify `tf plan` shows no change that rotates tunnel_secret before applying.
-# The import block can be removed after the first successful apply.
+# Terraform adopts the existing tunnel by id (import block) but deliberately
+# does NOT manage tunnel_secret: that secret is a cloudflared run credential
+# that already lives in secrets/buoy/cloudflare-tunnel.json, and Terraform
+# needs neither it to own the tunnel's identity nor to build the cfargotunnel
+# CNAMEs. Leaving it unset keeps the secret in exactly one place and means
+# `tf apply` can never rotate it (no downtime). The import block can be removed
+# after the first successful apply.
 resource "cloudflare_zero_trust_tunnel_cloudflared" "buoy" {
-  account_id    = var.cloudflare_account_id
-  name          = "buoy-tunnel"
-  config_src    = "local"
-  tunnel_secret = var.cloudflare_tunnel_secret
+  account_id = var.cloudflare_account_id
+  name       = "buoy-tunnel"
+  config_src = "local"
 }
 
 import {

--- a/infra/buoy/variables.tf
+++ b/infra/buoy/variables.tf
@@ -43,12 +43,6 @@ variable "cloudflare_tunnel_id" {
   type        = string
 }
 
-variable "cloudflare_tunnel_secret" {
-  description = "Existing buoy-tunnel secret - the TunnelSecret in `sops -d secrets/buoy/cloudflare-tunnel.json` (base64). Set to the current value so `tf apply` does not rotate it (no downtime)."
-  type        = string
-  sensitive   = true
-}
-
 variable "status_dns_record_id" {
   description = "Cloudflare DNS record ID of the existing status.<domain> CNAME, used only to import it (GET /zones/{zone_id}/dns_records?name=status.<domain>)."
   type        = string

--- a/infra/buoy/variables.tf
+++ b/infra/buoy/variables.tf
@@ -32,6 +32,28 @@ variable "cloudflare_api_token" {
   sensitive   = true
 }
 
+variable "cloudflare_account_id" {
+  description = "Cloudflare account ID that owns the buoy-tunnel"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_tunnel_id" {
+  description = "UUID of the existing buoy-tunnel (`cloudflared tunnel list`), used only to import it into Terraform state."
+  type        = string
+}
+
+variable "cloudflare_tunnel_secret" {
+  description = "Existing buoy-tunnel secret - the TunnelSecret in `sops -d secrets/buoy/cloudflare-tunnel.json` (base64). Set to the current value so `tf apply` does not rotate it (no downtime)."
+  type        = string
+  sensitive   = true
+}
+
+variable "status_dns_record_id" {
+  description = "Cloudflare DNS record ID of the existing status.<domain> CNAME, used only to import it (GET /zones/{zone_id}/dns_records?name=status.<domain>)."
+  type        = string
+}
+
 variable "data_disk_size" {
   description = "Size of the persistent data disk in GB"
   type        = number

--- a/infra/buoy/variables.tf
+++ b/infra/buoy/variables.tf
@@ -38,13 +38,19 @@ variable "cloudflare_account_id" {
   sensitive   = true
 }
 
+# Both of the below are only read by the import blocks in tunnel.tf / dns.tf, so
+# they can be dropped from secrets/infra/terraform.env once those are removed
+# after the first successful apply. cloudflared is not installed on eve, so look
+# the ids up over the API (GET /accounts/{account_id}/cfd_tunnel?name=buoy-tunnel
+# and GET /zones/{zone_id}/dns_records?type=CNAME&name=status.<domain>); the PR
+# that introduced these has the exact commands.
 variable "cloudflare_tunnel_id" {
-  description = "UUID of the existing buoy-tunnel (`cloudflared tunnel list`), used only to import it into Terraform state."
+  description = "UUID of the existing buoy-tunnel, used only to import it into Terraform state."
   type        = string
 }
 
 variable "status_dns_record_id" {
-  description = "Cloudflare DNS record ID of the existing status.<domain> CNAME, used only to import it (GET /zones/{zone_id}/dns_records?name=status.<domain>)."
+  description = "Cloudflare DNS record ID of the existing status.<domain> CNAME, used only to import it."
   type        = string
 }
 

--- a/machines/buoy/cloudflare-tunnel.nix
+++ b/machines/buoy/cloudflare-tunnel.nix
@@ -5,12 +5,15 @@
 {
   services.cloudflared = {
     enable = true;
-    # cloudflared tunnel create buoy-tunnel
+    # The tunnel itself is managed in Terraform (infra/buoy/tunnel.tf,
+    # config_src = "local"); ingress/routing stays here. Credentials come from
+    # the sops file below, matching the Terraform-managed tunnel id + secret.
     tunnels.buoy-tunnel = {
       credentialsFile = config.sops.secrets.cloudflare-tunnel.path;
       default = "http_status:404";
       ingress = {
-        # cloudflared tunnel route dns buoy-tunnel <hostname>
+        # DNS for tunnel hostnames is declared in infra/buoy/dns.tf (proxied
+        # CNAMEs to <tunnel-id>.cfargotunnel.com), not `cloudflared tunnel route dns`.
         "status.${config.my.domain}" =
           "http://localhost:${toString config.services.gatus.settings.web.port}";
       };

--- a/modules/home-manager/nh.nix
+++ b/modules/home-manager/nh.nix
@@ -30,9 +30,7 @@ in
       # bare: switch this machine. with an arg: deploy to that host over ssh
       ns() {
         if (( $# == 0 )); then
-          ${lib.getExe pkgs.nh} ${
-            if pkgs.stdenv.hostPlatform.isDarwin then "darwin" else "os"
-          } switch
+          ${lib.getExe pkgs.nh} ${if pkgs.stdenv.hostPlatform.isDarwin then "darwin" else "os"} switch
         else
           local host="$1"
           shift


### PR DESCRIPTION
## What

Brings the **buoy-tunnel** Cloudflare Tunnel under Terraform, replacing the two out-of-band steps (`cloudflared tunnel create` and `cloudflared tunnel route dns`). This is the declarative base that the ntfy PR (#8) stacks on: #8 targets this branch and references the tunnel resource, then re-points to `main` once this merges.

## Changes

- **`infra/buoy/tunnel.tf`** (new) — `cloudflare_zero_trust_tunnel_cloudflared.buoy` with `config_src = "local"` (cloudflared keeps managing ingress on the box via `machines/buoy/cloudflare-tunnel.nix`). An `import` block adopts the already-running tunnel by id. **Terraform does not manage `tunnel_secret`**: that run credential stays solely in `secrets/buoy/cloudflare-tunnel.json` (it is optional + write-only), so it isn't duplicated and `tf apply` can never rotate it.
- **`infra/buoy/dns.tf`** — `status.glib.sh` becomes a declarative proxied CNAME to the tunnel's `cfargotunnel.com` hostname, with an `import` block to adopt the record `cloudflared` created.
- **`infra/buoy/variables.tf`** — adoption inputs only: `cloudflare_account_id`, `cloudflare_tunnel_id`, `status_dns_record_id`. No tunnel-secret variable. The two import-only inputs document the API lookup rather than `cloudflared tunnel list`, since `cloudflared` is installed only on the hosts that run a tunnel (buoy, hoard), not on eve where terraform runs.
- **`machines/buoy/cloudflare-tunnel.nix`** — comments now point at the Terraform resources instead of the CLI. `credentialsFile` is unchanged (buoy keeps using the same sops creds; the tunnel id + secret don't change).
- **`modules/home-manager/nh.nix`** — collapse a multi-line string interpolation the current nixfmt pin reformats, so `flake-check` is green (pre-existing drift on `main`, unrelated).

Nothing here is deployed to buoy. The tunnel process, its credentials and the status page are untouched by this change; it only moves ownership of the tunnel object and its DNS record into Terraform state.

## Adoption runbook (one time, on eve)

Run the steps in order. Everything is copy-pasteable as written.

### 1. Branch and shell

```sh
cd ~/dotfiles
git fetch origin claude/buoy-tunnel-terraform
git checkout claude/buoy-tunnel-terraform
cd infra && nix develop ..#infra
```

(With direnv, `cd infra` is enough: `.envrc` loads the same shell.)

Confirm sops can decrypt the infra env file. Prints `sops OK` and nothing sensitive:

```sh
sops exec-env "$REPO_ROOT/secrets/infra/terraform.env" 'test -n "$TF_VAR_cloudflare_api_token" && echo "sops OK"'
```

If that fails inside `op read` because the account selector wants an answer, pin the account holding the `dev` vault and re-run the check:

```sh
op account list
export OP_ACCOUNT=THE_SHORTHAND_FROM_THAT_LIST
```

### 2. Make sure the GCE image file exists

`compute.tf:11` does `nixos_image_hash = filemd5(var.nixos_image_path)`, pointed by `terragrunt.hcl` at `infra/result`, which is gitignored. That local is read by a root output, and it depends only on a variable, so **`-target` does not prune it**: if the file is missing, every plan in this unit fails before it gets to the tunnel. Check:

```sh
cd "$REPO_ROOT/infra"
test -r result && echo "image present" || echo "image MISSING"
```

Only if it says MISSING:

```sh
nix build ..#packages.x86_64-linux.gce-image -o result
```

(That is an x86_64 build, so it goes to reaper over distributed builds; reaper needs to be up.)

If you had to rebuild, check whether the rebuild is byte-identical to what state recorded:

```sh
cd "$REPO_ROOT/infra/buoy" && tg output -raw nixos_image_hash; echo
md5 -q "$REPO_ROOT/infra/result"
```

If those two hashes differ, the image drifted (different `flake.lock` than at bootstrap, most likely). That is pre-existing and unrelated to this PR. The `-target` flags in steps 5 and 6 mean it cannot be applied, so carry on, but tell me and don't run an untargeted `apply`.

### 3. Look up the three import ids

One paste. The API token stays inside the subshell and is never printed:

```sh
sops exec-env "$REPO_ROOT/secrets/infra/terraform.env" '
set -eu
API=https://api.cloudflare.com/client/v4
AUTH="Authorization: Bearer $TF_VAR_cloudflare_api_token"

ACCOUNTS=$(curl -sS -H "$AUTH" "$API/accounts")
test "$(echo "$ACCOUNTS" | jq -r .success)" = true || { echo "accounts lookup failed: $ACCOUNTS"; exit 1; }
test "$(echo "$ACCOUNTS" | jq -r ".result | length")" = 1 || { echo "more than one account, pick one manually:"; echo "$ACCOUNTS" | jq -r ".result[] | .id + \"  \" + .name"; exit 1; }
ACCT=$(echo "$ACCOUNTS" | jq -r ".result[0].id")

TUN=$(curl -sS -H "$AUTH" "$API/accounts/$ACCT/cfd_tunnel?name=buoy-tunnel&is_deleted=false" | jq -r ".result[0].id // empty")
test -n "$TUN" || { echo "buoy-tunnel not found in account $ACCT"; exit 1; }

REC=$(curl -sS -H "$AUTH" "$API/zones/$TF_VAR_cloudflare_zone_id/dns_records?type=CNAME&name=status.$TF_VAR_domain_name")
RID=$(echo "$REC" | jq -r ".result[0].id // empty")
test -n "$RID" || { echo "status.$TF_VAR_domain_name CNAME not found"; exit 1; }

echo "content: $(echo "$REC" | jq -r ".result[0].content")   expected: $TUN.cfargotunnel.com"
echo "proxied: $(echo "$REC" | jq -r ".result[0].proxied")   ttl: $(echo "$REC" | jq -r ".result[0].ttl")   comment: $(echo "$REC" | jq -r ".result[0].comment // \"(none)\"")"
echo
echo "TF_VAR_cloudflare_account_id=$ACCT"
echo "TF_VAR_cloudflare_tunnel_id=$TUN"
echo "TF_VAR_status_dns_record_id=$RID"
'
```

Before continuing, check the first two printed lines: `content` must equal the `expected` value on the same line, `proxied` must be `true`, `ttl` must be `1`. If any of the three differs, stop here and paste the output.

### 4. Put the ids in the infra env file

```sh
sops "$REPO_ROOT/secrets/infra/terraform.env"
```

Append the three `TF_VAR_...=` lines printed by step 3, then save and quit. Verify they landed (both of these are identifiers, not secrets):

```sh
sops exec-env "$REPO_ROOT/secrets/infra/terraform.env" 'echo "$TF_VAR_cloudflare_tunnel_id $TF_VAR_status_dns_record_id"'
```

### 5. Plan, targeted so nothing else in this unit can move

```sh
cd "$REPO_ROOT/infra/buoy"
tg plan -target=cloudflare_zero_trust_tunnel_cloudflared.buoy -target=cloudflare_dns_record.status
```

Expected:

- `cloudflare_zero_trust_tunnel_cloudflared.buoy` **will be imported**, no attribute changes.
- `cloudflare_dns_record.status` **will be imported**, with at most one in-place change: `comment` set to `"Gatus status page via buoy-tunnel"` (`cloudflared tunnel route dns` does not set a comment, so step 3 will have printed `comment: (none)`).
- Summary: `Plan: 2 to import, 0 to add, 1 to change, 0 to destroy.` (`0 to change` if the comment already matches.)
- A `Resource targeting is in effect` warning. Expected, ignore it.

**Stop and do not apply** if you see any `destroy`, any `must be replaced`, `tunnel_secret` anywhere in the diff, a change to `content` / `proxied` / `ttl` on the status record, or any `google_` resource in the plan at all.

### 6. Apply

```sh
tg apply -target=cloudflare_zero_trust_tunnel_cloudflared.buoy -target=cloudflare_dns_record.status
```

The same diff is shown again. Check it against step 5, then type `yes`.

### 7. Verify

```sh
tg state list | grep cloudflare_
curl -sS -o /dev/null -w '%{http_code}\n' https://status.glib.sh
ssh buoy systemctl is-active cloudflared-tunnel-buoy-tunnel.service
```

Expect `cloudflare_dns_record.status`, `cloudflare_dns_record.vm` and `cloudflare_zero_trust_tunnel_cloudflared.buoy` in state, then `200`, then `active`.

### 8. Drop the import scaffolding

Once step 7 is clean, say so and I'll push the removal commit (both `import` blocks, plus the `cloudflare_tunnel_id` and `status_dns_record_id` variables). After that lands, pull it and remove the same two lines from the env file:

```sh
sops "$REPO_ROOT/secrets/infra/terraform.env"   # delete TF_VAR_cloudflare_tunnel_id and TF_VAR_status_dns_record_id
```

`TF_VAR_cloudflare_account_id` stays: the tunnel resource itself needs it. That leaves the tunnel id and the account tag each stored in exactly one place (Terraform state and `secrets/buoy/cloudflare-tunnel.json`) instead of being duplicated into the env file.

Then re-run step 5's targeted plan. Expect `No changes.`

### If the import blocks do not take under `-target`

If the plan in step 5 shows the resources as "will be created" instead of "will be imported", abort at the plan, import explicitly, and re-run step 5:

```sh
sops exec-env "$REPO_ROOT/secrets/infra/terraform.env" 'terragrunt import cloudflare_zero_trust_tunnel_cloudflared.buoy "$TF_VAR_cloudflare_account_id/$TF_VAR_cloudflare_tunnel_id"'
sops exec-env "$REPO_ROOT/secrets/infra/terraform.env" 'terragrunt import cloudflare_dns_record.status "$TF_VAR_cloudflare_zone_id/$TF_VAR_status_dns_record_id"'
```

Those go through `sops exec-env` directly rather than `tg` because the `tg` wrapper joins its arguments into a single string before sops runs, so `$TF_VAR_*` cannot be expanded through `tg`.

## Verification

- `nix flake check` runs in CI (no Nix in the session).
- Terraform is not validated locally (no `terraform` in the session), which is why step 5 is a targeted plan with explicit stop conditions rather than a bare `tg apply`.
- `.tf` files are not touched by `treefmt` (it formats only `.nix/.lua/.sh/.toml/.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)